### PR TITLE
feat: Add FastAPI endpoint for news surfing via MultiModalWebSurfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
+# News Summarizer API
 
+This project is a FastAPI application that uses a multimodal web surfer (Autogen's `MultiModalWebSurfer`) to fetch and summarize the latest news headlines.
+
+## Getting Started
+
+### Prerequisites
+
+*   **Python 3.7+**
+*   **Running Playwright Server:**
+    *   This application connects to an existing Playwright server. Ensure you have one running and accessible at `ws://localhost:3388`.
+    *   You might need to install Playwright system dependencies and browsers first: `python -m playwright install`
+    *   The Playwright server itself needs to be launched separately. The `connect_existing` option in the code implies that this application does not manage the server's lifecycle.
+*   **LLM API Key and Configuration:**
+    *   The application requires an LLM (e.g., OpenAI GPT model) to process and summarize the web content.
+    *   You need to update the placeholder LLM configuration in `main.py` with your actual API key and desired model. Look for the `llm_config` dictionary within the `/news` endpoint. Specifically, set the `OPENAI_API_KEY` environment variable or replace `"your_api_key_here"` directly.
+
+### Installation
+
+1.  **Clone the repository** (if you are working with this project locally):
+    ```bash
+    # git clone <repository_url>
+    # cd <repository_directory>
+    ```
+2.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+### Running the Application
+
+1.  Ensure your Playwright server is running on `ws://localhost:3388`.
+2.  Ensure you have configured your LLM API key in `main.py` or via the `OPENAI_API_KEY` environment variable.
+3.  Start the FastAPI application using Uvicorn:
+    ```bash
+    uvicorn main:app --reload --port 8000
+    ```
+    The application will be available at `http://localhost:8000`.
+
+## Endpoint
+
+### `/news`
+
+*   **Method:** `GET`
+*   **URL:** `/news`
+*   **Description:** Fetches and summarizes the top 3 latest news headlines from a pre-configured news source (e.g., BBC News) using a multimodal web surfing agent.
+*   **Success Response:**
+    *   **Code:** `200 OK`
+    *   **Content Example:**
+        ```json
+        {
+            "news_summary": "AI has made groundbreaking advancements in climate change prediction, according to recent reports..."
+        }
+        ```
+*   **Error Responses:**
+    *   **Code:** `503 Service Unavailable`
+        *   **Content Example (Playwright server unavailable):**
+            ```json
+            {
+                "detail": "Playwright server not available. Make sure it's running on ws://localhost:3388"
+            }
+            ```
+    *   **Code:** `500 Internal Server Error`
+        *   **Content Example (Other processing error):**
+            ```json
+            {
+                "detail": "An error occurred: Specific error message from the server."
+            }
+            ```
+
+## Running Tests
+
+To run the automated tests for this application:
+
+1.  Ensure you have installed the development dependencies (which should be covered by `requirements.txt` if `pytest` is included, or `unittest` is standard).
+2.  Navigate to the root directory of the project.
+3.  Run the tests using `pytest` (recommended) or `unittest`:
+
+    Using `pytest` (if you add `pytest` to `requirements.txt` and install it):
+    ```bash
+    pytest
+    ```
+
+    Or using `unittest`:
+    ```bash
+    python -m unittest discover tests
+    ```
+    This will discover and run all tests in the `tests` directory.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,44 @@
+import os
+from fastapi import FastAPI, HTTPException
+from autogen.agentchat.contrib.multimodal_web_surfer import MultiModalWebSurfer
+
+app = FastAPI()
+
+@app.get("/news")
+async def get_news():
+    try:
+        # Initialize MultiModalWebSurfer
+        news_surfer = MultiModalWebSurfer(
+            name="news_surfer",
+            # TODO: Replace with your actual LLM configuration
+            llm_config={
+                "config_list": [
+                    {
+                        "model": "gpt-3.5-turbo",
+                        "api_key": os.environ.get("OPENAI_API_KEY", "your_api_key_here"),
+                    }
+                ],
+                "temperature": 0,
+            },
+            browser_config={
+                "browser_type": "connect_existing",
+                "viewport_size": {"width": 1280, "height": 720},
+                "ws_endpoint": "ws://localhost:3388",
+            }
+        )
+
+        # Create a task for the web surfer
+        task = "Summarize the top 3 latest news headlines from BBC News."
+
+        # Get the news using the web surfer
+        agent_response = news_surfer.chat(task)
+
+        # Return the response as JSON
+        # Assuming agent_response itself is serializable or a string
+        return {"news_summary": agent_response}
+
+    except ConnectionRefusedError:
+        raise HTTPException(status_code=503, detail="Playwright server not available. Make sure it's running on ws://localhost:3388")
+    except Exception as e:
+        # Catch any other exceptions during the process
+        raise HTTPException(status_code=500, detail=f"An error occurred: {str(e)}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+autogen
+playwright

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,77 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+import pytest
+
+# Ensure the app can be imported. If main.py is in the root, this should work.
+# If your project structure is different, you might need to adjust the Python path.
+try:
+    from main import app
+except ImportError:
+    import sys
+    import os
+    # Add the parent directory to the sys.path to find the main module
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    from main import app
+
+
+client = TestClient(app)
+
+@patch('main.MultiModalWebSurfer')
+def test_get_news_success(MockMultiModalWebSurfer):
+    """
+    Test the /news endpoint for a successful response.
+    """
+    # Configure the mock MultiModalWebSurfer
+    mock_surfer_instance = MockMultiModalWebSurfer.return_value
+    mock_surfer_instance.chat.return_value = "Breaking News: AI solves world hunger!"
+
+    # Make a GET request to /news
+    response = client.get("/news")
+
+    # Assert that the response status code is 200
+    assert response.status_code == 200
+
+    # Assert that the response JSON contains the expected news summary
+    assert response.json() == {"news_summary": "Breaking News: AI solves world hunger!"}
+    MockMultiModalWebSurfer.assert_called_once()
+    mock_surfer_instance.chat.assert_called_once_with("Summarize the top 3 latest news headlines from BBC News.")
+
+@patch('main.MultiModalWebSurfer')
+def test_get_news_playwright_unavailable(MockMultiModalWebSurfer):
+    """
+    Test the /news endpoint when the Playwright server is unavailable.
+    """
+    # Configure the mock MultiModalWebSurfer's __init__ to raise ConnectionRefusedError
+    # This simulates the "connect_existing" browser_type failing.
+    MockMultiModalWebSurfer.side_effect = ConnectionRefusedError("Simulated Playwright connection failed")
+
+    # Make a GET request to /news
+    response = client.get("/news")
+
+    # Assert that the response status code is 503 (Service Unavailable)
+    assert response.status_code == 503
+
+    # Assert that the response JSON contains an appropriate error message
+    assert response.json() == {"detail": "Playwright server not available. Make sure it's running on ws://localhost:3388"}
+    MockMultiModalWebSurfer.assert_called_once()
+
+
+@patch('main.MultiModalWebSurfer')
+def test_get_news_generic_exception(MockMultiModalWebSurfer):
+    """
+    Test the /news endpoint for a generic exception during web surfing.
+    """
+    # Configure the mock MultiModalWebSurfer's chat method to raise a generic Exception
+    mock_surfer_instance = MockMultiModalWebSurfer.return_value
+    mock_surfer_instance.chat.side_effect = Exception("Simulated generic error during news retrieval")
+
+    # Make a GET request to /news
+    response = client.get("/news")
+
+    # Assert that the response status code is 500 (Internal Server Error)
+    assert response.status_code == 500
+
+    # Assert that the response JSON contains an appropriate error message
+    assert response.json() == {"detail": "An error occurred: Simulated generic error during news retrieval"}
+    MockMultiModalWebSurfer.assert_called_once()
+    mock_surfer_instance.chat.assert_called_once_with("Summarize the top 3 latest news headlines from BBC News.")


### PR DESCRIPTION
This commit introduces a FastAPI application with a `/news` endpoint. The endpoint utilizes AutoGen's `MultiModalWebSurfer` to browse the web and summarize the latest news headlines.

Key features:
- Configures `MultiModalWebSurfer` to connect to an existing Playwright server instance at `ws://localhost:3388`.
- Includes basic error handling for scenarios like Playwright server unavailability.
- Adds unit tests for the `/news` endpoint, mocking the web surfing functionality to ensure test reliability and speed.
- Provides a `requirements.txt` for dependency management.
- Updates `README.md` with instructions for setup, execution, endpoint usage, and running tests.

The LLM configuration in `main.py` uses a placeholder and needs to be updated by you with your actual API key and model preference.